### PR TITLE
add cmake install support, add ENABLE_IO and BUILD_EXAMPLES options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,24 @@ cmake_minimum_required(VERSION 3.18)
 
 project(StftPitchShift)
 
+option(ENABLE_BUILTIN "Use included external sources (drlibs wav I/O, pocketfft)" ON)
+option(ENABLE_IO "enable wav I/O support (needed for executable)" ON)
+option(BUILD_EXAMPLES "build examples" ON)
+option(BUILD_EXECUTABLE "build executable" ON)
+
 if (MSVC)
   # add_compile_options(/W3 /WX)
+  add_compile_options(/MP)
 else()
   # add_compile_options(-Wall -Werror)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/cpp/StftPitchShift/LibStftPitchShift.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/cpp/StftPitchShift/TheStftPitchShift.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/examples/example.cmake")
+
+if(BUILD_EXECUTABLE)
+  include("${CMAKE_CURRENT_LIST_DIR}/cpp/StftPitchShift/TheStftPitchShift.cmake")
+endif()
+
+if(BUILD_EXAMPLES)
+  include("${CMAKE_CURRENT_LIST_DIR}/examples/example.cmake")
+endif()

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,6 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+
+check_required_components(@PROJECT_NAME@)
+

--- a/README.md
+++ b/README.md
@@ -80,11 +80,12 @@ Will soon appear...
 Use [CMake](http://cmake.org) to build the C++ program and library like so:
 
 ```cmd
-mkdir build
+cmake -S . -B build [-DBUILD_EXAMPLES=OFF -DENABLE_IO=OFF -DENABLE_BUILTIN=OFF -DBUILD_EXECUTABLE=OFF]
 cd build
-cmake ..
 cmake --build .
 ```
+
+You can turn building I/O support (drlibs wav reader) and examples off to execute a minimal library only build. If you specify `-DENABLE_BUILTIN=OFF`, compilation will use externally provided pocketfft and dr_libs packages (useful for building via package managers like vcpkg).
 
 To include this library in your C++ audio project, check the [LibStftPitchShift.cmake](cpp/StftPitchShift/LibStftPitchShift.cmake) file and the following minimal example:
 

--- a/cpp/StftPitchShift/LibStftPitchShift.cmake
+++ b/cpp/StftPitchShift/LibStftPitchShift.cmake
@@ -1,45 +1,115 @@
 cmake_minimum_required(VERSION 3.18)
 
-project(LibStftPitchShift)
-
-include("${CMAKE_CURRENT_LIST_DIR}/dr_libs/CMakeLists.txt")
-include("${CMAKE_CURRENT_LIST_DIR}/pocketfft/CMakeLists.txt")
+project(LibStftPitchShift VERSION 1.3)
 
 add_library(LibStftPitchShift)
+
+if(ENABLE_BUILTIN)
+  #include("${CMAKE_CURRENT_LIST_DIR}/dr_libs/CMakeLists.txt")
+  #include("${CMAKE_CURRENT_LIST_DIR}/pocketfft/CMakeLists.txt")
+  find_path(POCKETFFT_INCLUDE_DIRS pocketfft_hdronly.h PATHS "${CMAKE_CURRENT_LIST_DIR}/pocketfft" REQUIRED)
+  find_path(DRLIBS_INCLUDE_DIRS "dr_wav.h" PATHS "${CMAKE_CURRENT_LIST_DIR}/dr_libs" REQUIRED)
+  if (UNIX)
+    target_link_libraries(pocketfft INTERFACE pthread)
+  endif()
+else()
+  find_package(pocketfft CONFIG REQUIRED)
+  find_path(DRLIBS_INCLUDE_DIRS "dr_wav.h" REQUIRED)
+  target_link_libraries(LibStftPitchShift PRIVATE pocketfft::pocketfft)
+endif()
 
 set_target_properties(LibStftPitchShift
   PROPERTIES OUTPUT_NAME "stftpitchshift"
 )
 
+set(HEADER_FILES
+  "${CMAKE_CURRENT_LIST_DIR}/Cepstrum.h"
+  "${CMAKE_CURRENT_LIST_DIR}/Dump.h"
+  "${CMAKE_CURRENT_LIST_DIR}/Pitcher.h"
+  "${CMAKE_CURRENT_LIST_DIR}/Resampler.h"
+  "${CMAKE_CURRENT_LIST_DIR}/STFT.h"
+  "${CMAKE_CURRENT_LIST_DIR}/StftPitchShift.h"
+  "${CMAKE_CURRENT_LIST_DIR}/Timer.h"
+  "${CMAKE_CURRENT_LIST_DIR}/Version.h"
+  "${CMAKE_CURRENT_LIST_DIR}/Vocoder.h"
+)
+
+if(ENABLE_IO)
+  list(APPEND HEADER_FILES "${CMAKE_CURRENT_LIST_DIR}/IO.h")
+endif()
+
 target_sources(LibStftPitchShift
-  PUBLIC "${CMAKE_CURRENT_LIST_DIR}/Cepstrum.h"
+  PRIVATE ${HEADER_FILES}
          "${CMAKE_CURRENT_LIST_DIR}/Cepstrum.cpp"
-         "${CMAKE_CURRENT_LIST_DIR}/Dump.h"
-         "${CMAKE_CURRENT_LIST_DIR}/IO.h"
-         "${CMAKE_CURRENT_LIST_DIR}/IO.cpp"
-         "${CMAKE_CURRENT_LIST_DIR}/Pitcher.h"
          "${CMAKE_CURRENT_LIST_DIR}/Pitcher.cpp"
-         "${CMAKE_CURRENT_LIST_DIR}/Resampler.h"
          "${CMAKE_CURRENT_LIST_DIR}/Resampler.cpp"
-         "${CMAKE_CURRENT_LIST_DIR}/STFT.h"
          "${CMAKE_CURRENT_LIST_DIR}/STFT.cpp"
-         "${CMAKE_CURRENT_LIST_DIR}/StftPitchShift.h"
          "${CMAKE_CURRENT_LIST_DIR}/StftPitchShift.cpp"
-         "${CMAKE_CURRENT_LIST_DIR}/Timer.h"
-         "${CMAKE_CURRENT_LIST_DIR}/Version.h"
-         "${CMAKE_CURRENT_LIST_DIR}/Vocoder.h"
          "${CMAKE_CURRENT_LIST_DIR}/Vocoder.cpp"
 )
 
+if(ENABLE_IO)
+  target_sources(LibStftPitchShift
+    PRIVATE "${CMAKE_CURRENT_LIST_DIR}/IO.cpp")
+endif()
+
+#-------------------------------------------------------------
+# install
+# https://cmake.org/cmake/help/git-stage/guide/importing-exporting/index.html
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
+
+
 target_include_directories(LibStftPitchShift
-  PUBLIC  "${CMAKE_CURRENT_LIST_DIR}/.."
-  PRIVATE "${CMAKE_CURRENT_LIST_DIR}"
+  PUBLIC  "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/..>"
+  PRIVATE "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>"
+  INTERFACE "$<INSTALL_INTERFACE:include/LibStftPitchShift>"
 )
 
-target_link_libraries(LibStftPitchShift
-  PUBLIC dr_libs pocketfft
+target_compile_definitions(LibStftPitchShift
+  PRIVATE -DDR_WAV_IMPLEMENTATION
 )
 
 target_compile_features(LibStftPitchShift
   PRIVATE cxx_std_11
 )
+
+
+
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(FILES ${HEADER_FILES}
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
+
+install(EXPORT ${PROJECT_NAME}Targets
+        FILE ${PROJECT_NAME}Targets.cmake
+        NAMESPACE ${PROJECT_NAME}::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+        "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+      )
+
+set_property(TARGET ${PROJECT_NAME} PROPERTY VERSION ${PROJECT_VERSION})
+set_property(TARGET ${PROJECT_NAME} PROPERTY SOVERSION 1)
+set_property(TARGET ${PROJECT_NAME} PROPERTY INTERFACE_${PROJECT_NAME}_MAJOR_VERSION 1)
+set_property(TARGET ${PROJECT_NAME} APPEND PROPERTY COMPATIBLE_INTERFACE_STRING ${PROJECT_NAME}_MAJOR_VERSION)
+      
+write_basic_package_version_file(
+    "${PROJECT_NAME}ConfigVersion.cmake"
+    VERSION "${PROJECT_VERSION}"
+    COMPATIBILITY AnyNewerVersion)
+
+install(
+    FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+    


### PR DESCRIPTION
also: BUILD_EXECUTABLE and ENABLE_BUILTIN.

all default to ON (behavior as before).

Allows minimal library build against external pocketfft, dr_libs.