### PR TITLE
Small compiler compliance fix (.get() for implicit bool)

### DIFF
--- a/cpp/StftPitchShift/StftPitchShiftCore.h
+++ b/cpp/StftPitchShift/StftPitchShiftCore.h
@@ -103,7 +103,7 @@ namespace stftpitchshift
 
     bool normalization() const
     {
-      return normalizer;
+      return normalizer.get();
     }
 
     void normalization(const bool normalization)

--- a/cpp/StftPitchShift/StftPitchShiftCore.h
+++ b/cpp/StftPitchShift/StftPitchShiftCore.h
@@ -103,7 +103,7 @@ namespace stftpitchshift
 
     bool normalization() const
     {
-      return normalizer.get();
+      return static_cast<bool>(normalizer);
     }
 
     void normalization(const bool normalization)


### PR DESCRIPTION
Changed shared_ptr to include .get() to allow for compiler compliant boolean conversion

Problem could be triggered by calling normalization() on the core on some compilers.
> _deps/stftpitchshift-src/cpp/StftPitchShift/StftPitchShiftCore.h:106:14: error: no viable conversion from returned value of type 'const std::shared_ptr<Normalizer<double>>' to function return type 'bool'
>   106 |       return normalizer;
>       |              ^~~~~~~~~~
> stfpitchshift.h:42:36: note: in instantiation of member function 'stftpitchshift::StftPitchShiftCore<double>::normalization' requested here
>    42 |         bool getNormalize() {return core->normalization();}
>       |                                           ^
> /usr/lib/gcc/x86_64-linux-gnu/15/../../../../include/c++/15/bits/shared_ptr_base.h:1676:16: note: explicit conversion function is not a candidate
>  1676 |       explicit operator bool() const noexcept
>       |                ^
> 2 errors generated.
